### PR TITLE
remove dict dynamic regularization

### DIFF
--- a/src/LDLFactorizations.jl
+++ b/src/LDLFactorizations.jl
@@ -129,12 +129,7 @@ end
 
 function ldl_numeric_upper!(n, Ap, Ai, Ax, Cp, Ci, Lp, parent, Lnz, Li, Lx, D, Y,
                             pattern, flag, P, Pinv; dynamic_args...)
-  if length(dynamic_args) != 0
-    dynamic_regul = true
-    dynamic_dict = Dict(dynamic_args)
-  else
-    dynamic_regul = false
-  end
+  dynamic_regul = length(dynamic_args) != 0 
   @inbounds for k = 1:n
     Y[k] = 0
     top = n+1
@@ -198,8 +193,8 @@ function ldl_numeric_upper!(n, Ap, Ai, Ax, Cp, Ci, Lp, parent, Lnz, Li, Lx, D, Y
       Lnz[i] += 1
       top += 1
     end
-    if dynamic_regul && abs(D[k]) < dynamic_dict[:tol]
-      r = P[k] <= dynamic_dict[:n_d] ? dynamic_dict[:r1] : dynamic_dict[:r2]
+    if dynamic_regul && abs(D[k]) < dynamic_args[:tol]
+      r = P[k] <= dynamic_args[:n_d] ? dynamic_args[:r1] : dynamic_args[:r2]
       D[k] = sign(r) * max(abs(D[k] + r), abs(r))
     end
     D[k] == 0 && throw(SQDException("matrix does not possess a LDL' factorization for this permutation"))

--- a/src/LDLFactorizations.jl
+++ b/src/LDLFactorizations.jl
@@ -128,9 +128,9 @@ function ldl_symbolic!(n, Ap, Ai, Lp, parent, Lnz, flag, P, Pinv)
 end
 
 function ldl_numeric_upper!(n, Ap, Ai, Ax, Cp, Ci, Lp, parent, Lnz, Li, Lx, D, Y,
-                            pattern, flag, P, Pinv, r1, r2, tol, n_d)
-  T = typeof(r1)
-  dynamic_reg = r1 > zero(T) || r2 > zero(T)  
+                            pattern, flag, P, Pinv; 
+                            r1=zero(eltype(Ax)), r2=zero(eltype(Ax)), tol=zero(eltype(Ax)), n_d=n)
+  dynamic_reg = r1 > 0 || r2 > 0 
   @inbounds for k = 1:n
     Y[k] = 0
     top = n+1
@@ -470,8 +470,7 @@ ldl_analyze(A::Symmetric{T,SparseMatrixCSC{T,Ti}}) where {T<:Real,Ti<:Integer} =
 
 function ldl_factorize!(A::Symmetric{T,SparseMatrixCSC{T,Ti}},
                         S::LDLFactorization{T,Ti,Tn,Tp};
-                        r1 :: T = zero(eltype(A)), r2 :: T = zero(eltype(A)), tol :: T = zero(eltype(A)), 
-                        n_d :: Int = 0) where {T<:Real,Ti<:Integer,Tn<:Integer,Tp<:Integer}
+                        dynamic_args...) where {T<:Real,Ti<:Integer,Tn<:Integer,Tp<:Integer}
   S.__analyzed || error("perform symbolic analysis prior to numerical factorization")
   n = size(A, 1)
   n == S.n || throw(DimensionMismatch("matrix size is inconsistent with symbolic analysis object"))
@@ -487,8 +486,8 @@ function ldl_factorize!(A::Symmetric{T,SparseMatrixCSC{T,Ti}},
 
   # perform numerical factorization
   ldl_numeric_upper!(S.n, A.data.colptr, A.data.rowval, A.data.nzval,
-                     S.Cp, S.Ci, S.Lp, S.parent, S.Lnz, S.Li, S.Lx, S.d, S.Y, S.pattern, S.flag, S.P, S.pinv,
-                     r1, r2, tol, n_d)
+                     S.Cp, S.Ci, S.Lp, S.parent, S.Lnz, S.Li, S.Lx, S.d, S.Y, S.pattern, S.flag, S.P, S.pinv;
+                     dynamic_args...)
   return S
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -196,13 +196,14 @@ end
        0.   0.   0.   5.   7.   9.   0.   2.   7.   1.
        3.   2.   0.   0.   0.   0.   1.   3.   3.   2.
        0.   0.   0.   0.  -3   -4    0.   0.   0.   0. ]
+  ϵ = sqrt(eps(eltype(A)))
   M = A * A'  # det(A) = 0 => M positive semidefinite
   b = M * ones(10)
   x = copy(b)
   S = ldl_analyze(Symmetric(triu(M), :U))
-  S.r1 = -1e-8
-  S.r2 = 1e-8
-  S.tol = 1e-8
+  S.r1 = -ϵ
+  S.r2 = ϵ
+  S.tol = ϵ
   S.n_d = 0
   S = ldl_factorize!(Symmetric(triu(M), :U), S)
   x = ldiv!(S, x)
@@ -221,6 +222,7 @@ end
        0.   0.   0.   5.   7.   9.   0.   2.   7.   1.
        3.   2.   0.   0.   0.   0.   1.   3.   3.   2.
        0.   0.   0.   0.  -3   -4    0.   0.   0.   0. ]
+  ϵ = sqrt(eps(eltype(A)))
   M = spzeros(20, 20)
   M[1:10, 1:10] = -A * A'
   M[11:20, 11:20] = A * A'
@@ -229,9 +231,9 @@ end
   b = M * ones(20)
   x = copy(b)
   S = ldl_analyze(Symmetric(triu(M), :U))
-  S.r1 = -1e-8
-  S.r2 = 1e-8
-  S.tol = 1e-8
+  S.r1 = -ϵ
+  S.r2 = ϵ
+  S.tol = ϵ
   S.n_d = 0
   S = ldl_factorize!(Symmetric(triu(M), :U), S)
   x = ldiv!(S, x)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -200,7 +200,11 @@ end
   b = M * ones(10)
   x = copy(b)
   S = ldl_analyze(Symmetric(triu(M), :U))
-  S = ldl_factorize!(Symmetric(triu(M), :U), S, tol=1e-8, r1=0., r2=1e-8, n_d=0)
+  S.r1 = -1e-8
+  S.r2 = 1e-8
+  S.tol = 1e-8
+  S.n_d = 0
+  S = ldl_factorize!(Symmetric(triu(M), :U), S)
   x = ldiv!(S, x)
   r = M * x - b
   @test norm(r) ≤ sqrt(eps()) * norm(b)
@@ -225,7 +229,11 @@ end
   b = M * ones(20)
   x = copy(b)
   S = ldl_analyze(Symmetric(triu(M), :U))
-  S = ldl_factorize!(Symmetric(triu(M), :U), S, tol=1e-8, r1=-1e-8, r2=1e-8, n_d=0)
+  S.r1 = -1e-8
+  S.r2 = 1e-8
+  S.tol = 1e-8
+  S.n_d = 0
+  S = ldl_factorize!(Symmetric(triu(M), :U), S)
   x = ldiv!(S, x)
   r = M * x - b
   @test norm(r) ≤ sqrt(eps()) * norm(b)


### PR DESCRIPTION
The dictionnary seems to create unnecessary allocations when using the dynamic regularization with my interior-point code, and is actually not needed, so I removed it 