### PR TITLE
Set boolean as true if allocated memory

### DIFF
--- a/src/LDLFactorizations.jl
+++ b/src/LDLFactorizations.jl
@@ -486,6 +486,7 @@ function ldl_factorize!(A::Symmetric{T,SparseMatrixCSC{T,Ti}},
     S.d = Vector{T}(undef, n)
     S.Y = Vector{T}(undef, n)
     S.pattern = Vector{Ti}(undef, n)
+    S.__factorized = true
   end
 
   # perform numerical factorization
@@ -569,6 +570,7 @@ function ldl_factorize!(A::SparseMatrixCSC{T,Ti},
     S.d = Vector{T}(undef, n)
     S.Y = Vector{T}(undef, n)
     S.pattern = Vector{Ti}(undef, n)
+    S.__factorized = true
   end
 
   ldl_numeric!(S.n, A.colptr, A.rowval, A.nzval, S.Lp, S.parent, S.Lnz,

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -271,6 +271,27 @@ end
   @test norm(r) ≤ sqrt(eps()) * norm(b)
 end
 
+@testset "Successive factorizations" begin
+  A = spdiagm(0 => 2 * ones(10), 1 => -ones(9))
+  ϵ = √eps()
+  M1 = spzeros(20, 20)
+  M1[1:10, 1:10] = A
+  M1[11:20, 11:20] = spdiagm(0 => -ϵ * ones(10))
+  M2 = spzeros(20, 20)
+  M2[1:10, 1:10] = A
+  M2[11:20, 11:20] = spdiagm(0 => -100ϵ * ones(10))
+
+  S = ldl_analyze(M1)
+  @test !S.__factorized
+  _allocs1 = @allocated ldl_factorize!(M1, S)
+  @test S.__factorized
+  @test S.d[11:20] ≈ -ϵ * ones(10)
+  _allocs2 = @allocated ldl_factorize!(M2, S)
+  @test S.__factorized
+  @test S.d[11:20] ≈ -100ϵ * ones(10)
+  @test _allocs1 > _allocs2
+end
+
 @testset "ldl_mul!" begin
   A0 = [0.   0.   0.   0.   0.   0.   0.   0.   4.   0.
         0.   0.   1.   0.   0.   0.   0.   0.   5.   0.


### PR DESCRIPTION
When reusing the `ldl_analyze` for matrices with the same sparsity pattern we avoid reallocating memory.

Note that even if the factorization failed, the memory has been allocated.