### PR TITLE
Allocate memory in analysis

### DIFF
--- a/src/LDLFactorizations.jl
+++ b/src/LDLFactorizations.jl
@@ -457,12 +457,12 @@ function ldl_analyze(A::Symmetric{T,SparseMatrixCSC{T,Ti}}, P::Vector{Tp}) where
   ldl_symbolic_upper!(n, A.data.colptr, A.data.rowval, Cp, Ci, Lp, parent, Lnz, flag, P, pinv)
 
   # space for numerical factorization will be allocated later
-  Li = Ti[]
-  Lx = T[]
-  D = T[]
-  Y = T[]
-  pattern = Ti[]
-  return LDLFactorization(true, false, true, n, parent, Lnz, flag, P, pinv, Lp, Cp, Ci, Li, Lx, D, Y, pattern,
+  Li = Vector{Ti}(undef, Lp[n] - 1)
+  Lx = Vector{T}(undef, Lp[n] - 1)
+  d = Vector{T}(undef, n)
+  Y = Vector{T}(undef, n)
+  pattern = Vector{Ti}(undef, n)
+  return LDLFactorization(true, false, true, n, parent, Lnz, flag, P, pinv, Lp, Cp, Ci, Li, Lx, d, Y, pattern,
                           zero(T), zero(T), zero(T), n)
 end
 
@@ -478,15 +478,6 @@ function ldl_factorize!(A::Symmetric{T,SparseMatrixCSC{T,Ti}},
   S.__analyzed || error("perform symbolic analysis prior to numerical factorization")
   n = size(A, 1)
   n == S.n || throw(DimensionMismatch("matrix size is inconsistent with symbolic analysis object"))
-
-  # allocate space for numerical factorization if not already done
-  if !(S.__factorized)
-    S.Li = Vector{Ti}(undef, S.Lp[n] - 1)
-    S.Lx = Vector{T}(undef, S.Lp[n] - 1)
-    S.d = Vector{T}(undef, n)
-    S.Y = Vector{T}(undef, n)
-    S.pattern = Vector{Ti}(undef, n)
-  end
 
   # perform numerical factorization
   ldl_numeric_upper!(S.n, A.data.colptr, A.data.rowval, A.data.nzval,
@@ -540,12 +531,12 @@ function ldl_analyze(A::SparseMatrixCSC{T,Ti}, P::Vector{Tp}) where {T<:Real,Ti<
   ldl_symbolic!(n, A.colptr, A.rowval, Lp, parent, Lnz, flag, P, pinv)
 
   # space for numerical factorization will be allocated later
-  Li = Ti[]
-  Lx = T[]
-  D = T[]
-  Y = T[]
-  pattern = Ti[]
-  return LDLFactorization(true, false, false, n, parent, Lnz, flag, P, pinv, Lp, Cp, Ci, Li, Lx, D, Y, pattern,
+  Li = Vector{Ti}(undef, Lp[n] - 1)
+  Lx = Vector{T}(undef, Lp[n] - 1)
+  d = Vector{T}(undef, n)
+  Y = Vector{T}(undef, n)
+  pattern = Vector{Ti}(undef, n)
+  return LDLFactorization(true, false, false, n, parent, Lnz, flag, P, pinv, Lp, Cp, Ci, Li, Lx, d, Y, pattern,
                           zero(T), zero(T), zero(T), n)
 end
 
@@ -562,14 +553,6 @@ function ldl_factorize!(A::SparseMatrixCSC{T,Ti},
   S.__analyzed || error("perform symbolic analysis prior to numerical factorization")
   n = size(A, 1)
   n == S.n || throw(DimensionMismatch("matrix size is inconsistent with symbolic analysis object"))
-
-  if !(S.__factorized)
-    S.Li = Vector{Ti}(undef, S.Lp[n] - 1)
-    S.Lx = Vector{T}(undef, S.Lp[n] - 1)
-    S.d = Vector{T}(undef, n)
-    S.Y = Vector{T}(undef, n)
-    S.pattern = Vector{Ti}(undef, n)
-  end
 
   ldl_numeric!(S.n, A.colptr, A.rowval, A.nzval, S.Lp, S.parent, S.Lnz,
                S.Li, S.Lx, S.d, S.Y, S.pattern, S.flag, S.P, S.pinv)

--- a/src/LDLFactorizations.jl
+++ b/src/LDLFactorizations.jl
@@ -1,6 +1,6 @@
 module LDLFactorizations
 
-export ldl, ldl_analyze, ldl_factorize!, \, ldiv!, lmul!, mul!, nnz
+export ldl, ldl_analyze, ldl_factorize!, factorized, \, ldiv!, lmul!, mul!, nnz
 
 using AMD, LinearAlgebra, SparseArrays
 
@@ -428,6 +428,8 @@ mutable struct LDLFactorization{T<:Real,Ti<:Integer,Tn<:Integer,Tp<:Integer}
   tol::T
   n_d::Tn
 end
+
+factorized(LDL::LDLFactorization{T,Ti,Tn,Tp}) where {T<:Real,Ti<:Integer,Tn<:Integer,Tp<:Integer} = LDL.__factorized
 
 # perform symbolic analysis so it can be reused
 function ldl_analyze(A::Symmetric{T,SparseMatrixCSC{T,Ti}}, P::Vector{Tp}) where {T<:Real,Ti<:Integer,Tp<:Integer}

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -300,6 +300,8 @@ end
   b = ones(20)
   @test_throws LDLFactorizations.SQDException ldiv!(S, b)
   @test_throws LDLFactorizations.SQDException lmul!(S, b)
+  B = ones(20, 2)
+  @test_throws LDLFactorizations.SQDException ldiv!(S, B)
 end
 
 @testset "ldl_mul!" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -280,15 +280,26 @@ end
   M2 = spzeros(20, 20)
   M2[1:10, 1:10] = A
   M2[11:20, 11:20] = spdiagm(0 => -100ϵ * ones(10))
+  M3 = spzeros(20, 20)
+  M3[1:10, 1:10] = A
+  M3[11:20, 11:20] = spdiagm(0 => zeros(10))
 
   S = ldl_analyze(M1)
   @test S.__analyzed
   @test !S.__factorized
   _allocs1 = @allocated ldl_factorize!(M1, S)
   @test S.d[11:20] ≈ -ϵ * ones(10)
+  @test S.__factorized
   _allocs2 = @allocated ldl_factorize!(M2, S)
   @test S.d[11:20] ≈ -100ϵ * ones(10)
   @test _allocs1 == _allocs2
+
+  @test_throws LDLFactorizations.SQDException ldl_factorize!(M3, S)
+  @test !S.__factorized
+
+  b = ones(20)
+  @test_throws LDLFactorizations.SQDException ldiv!(S, b)
+  @test_throws LDLFactorizations.SQDException lmul!(S, b)
 end
 
 @testset "ldl_mul!" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -285,18 +285,15 @@ end
   M3[11:20, 11:20] = spdiagm(0 => zeros(10))
 
   S = ldl_analyze(M1)
-  @test S.__analyzed
-  @test !S.__factorized
+  @test !factorized(S)
   _allocs1 = @allocated ldl_factorize!(M1, S)
   @test S.d[11:20] ≈ -ϵ * ones(10)
-  @test S.__factorized
+  @test factorized(S)
   _allocs2 = @allocated ldl_factorize!(M2, S)
   @test S.d[11:20] ≈ -100ϵ * ones(10)
   @test _allocs1 == _allocs2
-
   @test_throws LDLFactorizations.SQDException ldl_factorize!(M3, S)
-  @test !S.__factorized
-
+  @test !factorized(S)
   b = ones(20)
   @test_throws LDLFactorizations.SQDException ldiv!(S, b)
   @test_throws LDLFactorizations.SQDException lmul!(S, b)


### PR DESCRIPTION
Alternative to PR #74 
- allocate memory for the factorization in `ldl_analyze`
~~- set `__factorized` as true if the factorization is successful~~