### PR TITLE
Update CI workflow to use 'lts' version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: ['1.6', '1']
+        version: ['lts', '1']
         os: [ubuntu-latest, macOS-latest, windows-latest]
         arch: [x64]
         allow_failure: [false]


### PR DESCRIPTION
Tests are failing with `julia 1.6`, see for example [this comment](https://github.com/JuliaSmoothOptimizers/LDLFactorizations.jl/pull/148#issuecomment-4206462166).